### PR TITLE
[codex] fix runner multiprocessing paths

### DIFF
--- a/babyai/run.py
+++ b/babyai/run.py
@@ -116,9 +116,11 @@ def get_index_from_gpt(
         model,
         system_message,
         print_response=PRINT_LLM_DEBUG,
-        msg_history=[],
+        msg_history=None,
         chat_history_len=3,
 ):
+    if msg_history is None:
+        msg_history = []
     new_msg_history = msg_history + [{"role": "user", "content": msg}]
     response = client.chat.completions.create(
         model=model,
@@ -405,12 +407,20 @@ def evaluate_single_performance(env, seed, agent, num_trials=1, max_actions_per=
     return success, total_reward, agent.total_cost, num_states_in_archive
 
 
+def run_evaluations(inputs, use_multiprocessing, max_workers):
+    if use_multiprocessing:
+        with ProcessPoolExecutor(max_workers=max_workers) as executor:
+            return list(executor.map(evaluate_single_performance, *zip(*inputs)))
+
+    return [evaluate_single_performance(*args) for args in inputs]
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--env_name', type=str, default='BabyAI-MixedTestLocal-v0')
     parser.add_argument('--min_seed', type=int, default=0)
     parser.add_argument('--max_seed', type=int, default=25)
-    parser.add_argument('--multiprocessing', action='store_true', default=True)
+    parser.add_argument('--multiprocessing', action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument('--debug_mode', action='store_true', default=False)
     parser.add_argument('--save_path', type=str, default='babyai_text_perf.pkl')
     parser.add_argument('--model',
@@ -423,11 +433,10 @@ def main():
         global env_types
         env_types = ['open']
         args.max_seed = 1
-        args.multi_processing = False
+        args.multiprocessing = False
 
     max_workers = os.cpu_count() if args.multiprocessing else 1
     print(f'Using {max_workers} workers')
-    executor = ProcessPoolExecutor(max_workers=max_workers)
 
     envs = separate_types(args.env_name)
     successes = defaultdict(list)
@@ -453,7 +462,7 @@ def main():
 
             inputs = [(copy.deepcopy(env), seed, agent_type(env.env.max_steps), num_trials, max_actions_per) for seed in
                       range(args.min_seed, args.max_seed)]
-            results = list(executor.map(evaluate_single_performance, *zip(*inputs)))
+            results = run_evaluations(inputs, args.multiprocessing, max_workers)
 
             for success, _, cost, num_states in tqdm.tqdm(results):
                 total_success += max(success)

--- a/game_of_24/run.py
+++ b/game_of_24/run.py
@@ -130,9 +130,11 @@ def get_index_from_gpt(
         model,
         system_message,
         print_response=PRINT_LLM_DEBUG,
-        msg_history=[],
+        msg_history=None,
         chat_history_len=5,
 ):
+    if msg_history is None:
+        msg_history = []
     new_msg_history = msg_history + [{"role": "user", "content": msg}]
     response = client.chat.completions.create(
         model=model,
@@ -509,12 +511,20 @@ def run_trial(init_state, target_number, max_actions, agent_class, model):
     return None, agent.total_cost, num_states_in_archive
 
 
+def run_trials(inputs, use_multiprocessing, max_workers):
+    if use_multiprocessing:
+        with ProcessPoolExecutor(max_workers=max_workers) as executor:
+            return list(executor.map(run_trial, *zip(*inputs)))
+
+    return [run_trial(*args) for args in inputs]
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--min_idx', type=int, default=900)
     parser.add_argument('--num_problems', type=int, default=100)
     parser.add_argument('--max_actions', type=int, default=700)
-    parser.add_argument('--multiprocessing', action='store_true', default=True)
+    parser.add_argument('--multiprocessing', action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument('--debug_mode', action='store_true', default=False)
     parser.add_argument('--save_path', type=str, default='time_to_success.json')
     parser.add_argument('--model', type=str,
@@ -528,7 +538,6 @@ def main():
 
     max_workers = os.cpu_count() if args.multiprocessing else 1
     print(f'Using {max_workers} workers')
-    executor = ProcessPoolExecutor(max_workers=max_workers)
 
     task = Game24Task()
     target_number = 24
@@ -549,7 +558,7 @@ def main():
 
         inputs = [task.get_input(idx=idx) for idx in range(args.min_idx, args.min_idx + args.num_problems)]
         inputs = [(x, target_number, args.max_actions, agent, args.model) for x in inputs]
-        results = executor.map(run_trial, *zip(*inputs))
+        results = run_trials(inputs, args.multiprocessing, max_workers)
 
         for result in tqdm.tqdm(results, total=args.num_problems):
             if result[0] is not None:

--- a/textworld/run_coin.py
+++ b/textworld/run_coin.py
@@ -310,7 +310,7 @@ class Reflexion(NaiveLLM):
 
     def reset_state(self):
         self.reflect_mode = True
-        self.reflexion_queue.append((self.acts_queue, self.obs_queue))
+        self.reflexion_queue.append((copy.deepcopy(self.acts_queue), copy.deepcopy(self.obs_queue)))
 
         self.obs_queue = copy.deepcopy(self.init_obs_queue)
         self.acts_queue = []
@@ -453,10 +453,18 @@ def evaluate_single_performance(env_id, agent_name, agent, num_trials=1, max_act
     return success, game_state['won'], (agent.total_cost, j * max_actions_per + actions_taken), agent_name, env_id
 
 
+def run_evaluations(inputs, use_multiprocessing, max_workers):
+    if use_multiprocessing:
+        with ProcessPoolExecutor(max_workers=max_workers) as executor:
+            return list(executor.map(evaluate_single_performance, *zip(*inputs)))
+
+    return [evaluate_single_performance(*args) for args in inputs]
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--game_dir', type=str, default='textworld/tw_games/coin_collector')
-    parser.add_argument('--multiprocessing', action='store_true', default=True)
+    parser.add_argument('--multiprocessing', action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument('--save_dir', type=str, default='results/')
     parser.add_argument('--debug_mode', action='store_true', default=False)
     parser.add_argument('--model',
@@ -481,7 +489,6 @@ def main():
 
     max_workers = len(env_ids) if args.multiprocessing else 1
     print(f'Using {max_workers} workers')
-    executor = ProcessPoolExecutor(max_workers=max_workers)
 
     for agent_name, agent_type, num_trials, max_actions_per in agent_types:
         total_num = 0
@@ -491,12 +498,14 @@ def main():
 
         inputs = [(env_id, agent_name, agent_type(max_steps, agent_name), num_trials, max_actions_per) for env_id in
                   env_ids]
-        results = list(executor.map(evaluate_single_performance, *zip(*inputs)))
+        results = run_evaluations(inputs, args.multiprocessing, max_workers)
 
         for res in results:
             try:
+                env_dir = os.path.basename(os.path.dirname(res[-1]))
+                env_file = os.path.basename(res[-1])
                 file_path = os.path.join(args.save_dir,
-                                         f"{agent_name}/{res[-1].split('/')[-2]}/{res[-1].split('/')[-1]}.pkl")
+                                         f"{agent_name}/{env_dir}/{env_file}.pkl")
                 os.makedirs(os.path.dirname(file_path), exist_ok=True)
                 with open(file_path, 'wb') as f:
                     pickle.dump(res, f)

--- a/textworld/run_cooking.py
+++ b/textworld/run_cooking.py
@@ -448,10 +448,18 @@ def evaluate_single_performance(env_id, agent_name, agent, num_trials=1, max_act
     return success, agent.max_score, (agent.total_cost, j * max_actions_per + actions_taken), agent_name, env_id
 
 
+def run_evaluations(inputs, use_multiprocessing, max_workers):
+    if use_multiprocessing:
+        with ProcessPoolExecutor(max_workers=max_workers) as executor:
+            return list(executor.map(evaluate_single_performance, *zip(*inputs)))
+
+    return [evaluate_single_performance(*args) for args in inputs]
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--game_dir', type=str, default='textworld/tw_games/the_cooking_game')
-    parser.add_argument('--multiprocessing', action='store_true', default=True)
+    parser.add_argument('--multiprocessing', action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument('--save_dir', type=str, default='results/')
     parser.add_argument('--debug_mode', action='store_true', default=False)
     parser.add_argument('--model',
@@ -479,7 +487,6 @@ def main():
 
     max_workers = len(env_ids) if args.multiprocessing else 1
     print(f'Using {max_workers} workers')
-    executor = ProcessPoolExecutor(max_workers=max_workers)
 
     for agent_name, agent_type, num_trials, max_actions_per in agent_types:
         total_num = 0
@@ -489,12 +496,14 @@ def main():
 
         inputs = [(env_id, agent_name, agent_type(max_steps, agent_name), num_trials, max_actions_per) for env_id in
                   env_ids]
-        results = list(executor.map(evaluate_single_performance, *zip(*inputs)))
+        results = run_evaluations(inputs, args.multiprocessing, max_workers)
 
         for res in results:
             try:
+                env_dir = os.path.basename(os.path.dirname(res[-1]))
+                env_file = os.path.basename(res[-1])
                 file_path = os.path.join(args.save_dir,
-                                         f"{agent_name}/{res[-1].split('/')[-2]}/{res[-1].split('/')[-1]}.pkl")
+                                         f"{agent_name}/{env_dir}/{env_file}.pkl")
                 os.makedirs(os.path.dirname(file_path), exist_ok=True)
                 with open(file_path, 'wb') as f:
                     pickle.dump(res, f)

--- a/textworld/run_treasure.py
+++ b/textworld/run_treasure.py
@@ -337,7 +337,7 @@ class Reflexion(NaiveLLM):
 
     def reset_state(self):
         self.reflect_mode = True
-        self.reflexion_queue.append((self.acts_queue, self.obs_queue))
+        self.reflexion_queue.append((copy.deepcopy(self.acts_queue), copy.deepcopy(self.obs_queue)))
 
         self.obs_queue = copy.deepcopy(self.init_obs_queue)
         self.acts_queue = []
@@ -452,10 +452,18 @@ def evaluate_single_performance(env_id, agent_name, agent, num_trials=1, max_act
     return success, game_state['won'], (agent.total_cost, j * max_actions_per + actions_taken), agent_name, env_id
 
 
+def run_evaluations(inputs, use_multiprocessing, max_workers):
+    if use_multiprocessing:
+        with ProcessPoolExecutor(max_workers=max_workers) as executor:
+            return list(executor.map(evaluate_single_performance, *zip(*inputs)))
+
+    return [evaluate_single_performance(*args) for args in inputs]
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--game_dir', type=str, default='textworld/tw_games/treasure_hunter')
-    parser.add_argument('--multiprocessing', action='store_true', default=True)
+    parser.add_argument('--multiprocessing', action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument('--save_dir', type=str, default='results/')
     parser.add_argument('--debug_mode', action='store_true', default=False)
     parser.add_argument('--model',
@@ -480,7 +488,6 @@ def main():
 
     max_workers = len(env_ids) if args.multiprocessing else 1
     print(f'Using {max_workers} workers')
-    executor = ProcessPoolExecutor(max_workers=max_workers)
 
     for agent_name, agent_type, num_trials, max_actions_per in agent_types:
         total_num = 0
@@ -490,12 +497,14 @@ def main():
 
         inputs = [(env_id, agent_name, agent_type(max_steps, agent_name), num_trials, max_actions_per) for env_id in
                   env_ids]
-        results = list(executor.map(evaluate_single_performance, *zip(*inputs)))
+        results = run_evaluations(inputs, args.multiprocessing, max_workers)
 
         for res in results:
             try:
+                env_dir = os.path.basename(os.path.dirname(res[-1]))
+                env_file = os.path.basename(res[-1])
                 file_path = os.path.join(args.save_dir,
-                                         f"{agent_name}/{res[-1].split('/')[-2]}/{res[-1].split('/')[-1]}.pkl")
+                                         f"{agent_name}/{env_dir}/{env_file}.pkl")
                 os.makedirs(os.path.dirname(file_path), exist_ok=True)
                 with open(file_path, 'wb') as f:
                     pickle.dump(res, f)


### PR DESCRIPTION
## What changed
This updates the BabyAI, Game of 24, and TextWorld runners to clean up a few small but user-visible execution issues.

- replace mutable default `msg_history=[]` helper arguments with `None`
- make `--no-multiprocessing` run inline instead of through a single-worker `ProcessPoolExecutor`
- fix the BabyAI debug-mode typo so it actually disables multiprocessing
- make TextWorld result-save paths use `os.path` helpers instead of hard-coded `/` splitting
- align Reflexion history snapshots to store deep copies where needed

## Why
The root cause was a mix of small runner footguns:

- the new boolean CLI exposed a non-multiprocessing mode, but execution still went through a child process
- BabyAI debug mode wrote to the wrong argument name
- helper defaults could accidentally share list state across calls
- TextWorld save paths were Unix-specific

Together these made debugging and local execution less predictable than the CLI implied.

## Impact
Users can now rely on `--no-multiprocessing` and BabyAI debug mode to stay in-process, which avoids unnecessary spawn/pickling behavior during debugging. The runner helpers are also a bit safer and more portable.

## Validation
- `python -m compileall babyai/run.py game_of_24/run.py textworld/run_coin.py textworld/run_cooking.py textworld/run_treasure.py`
- `git diff --check`
- local review pass found no remaining blocking issues